### PR TITLE
fix cloning of the course repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To run this project, you will need to add the following environment variables to
 Clone the project
 
 ```bash
-  git clone [https://github.com/emarco177/ice_breaker/blob/main/](https://github.com/emarco177/ice_breaker.git
+  git clone https://github.com/emarco177/ice_breaker.git
 ```
 
 Go to the project directory


### PR DESCRIPTION
There is a syntax error that has a missing parenthesis. Also, it makes sense to keep git clone simple so I have just kept the .git part. This will make it easy for the students to clone the repo