### PR TITLE
Add .idea/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
This PR adds .idea/ to .gitignore to exclude JetBrains IDE configuration files from version control. 
These files are user-specific and not essential to the codebase, which helps prevent unnecessary clutter and potential merge conflicts. Keeping them untracked ensures a cleaner repository and improves collaboration.