### PR TITLE
fix: rename linkedInUrl parameter to linkedin_url

### DIFF
--- a/third_parties/linkedin.py
+++ b/third_parties/linkedin.py
@@ -19,7 +19,7 @@ def scrape_linkedin_profile(linkedin_profile_url: str, mock: bool = False):
         api_endpoint = "https://api.scrapin.io/enrichment/profile"
         params = {
             "apikey": os.environ["SCRAPIN_API_KEY"],
-            "linkedInUrl": linkedin_profile_url,
+            "linkedin_url": linkedin_profile_url,
         }
         response = requests.get(
             api_endpoint,


### PR DESCRIPTION
Renamed the API parameter from "linkedInUrl" to "linkedin_url" in the LinkedIn scraping function as requested in issue #27.

Changes:
- Updated parameter name in `third_parties/linkedin.py` line 22

Fixes #27

Generated with [Claude Code](https://claude.ai/code)